### PR TITLE
Allow updates for string-based date values

### DIFF
--- a/source/kit/components/ui/inlineDatepicker.js
+++ b/source/kit/components/ui/inlineDatepicker.js
@@ -117,6 +117,10 @@
                             return true;
                         }
 
+                        if(typeof ngModel.$viewValue.getTime === 'undefined') {
+                            return true;
+                        }
+
                         return initialValue.getTime() !== ngModel.$viewValue.getTime();
                     }
 

--- a/source/kit/components/ui/inlineDatepicker.js
+++ b/source/kit/components/ui/inlineDatepicker.js
@@ -117,7 +117,7 @@
                             return true;
                         }
 
-                        if(typeof ngModel.$viewValue.getTime === 'undefined') {
+                        if(typeof initialValue.getTime === 'undefined' || typeof ngModel.$viewValue.getTime === 'undefined') {
                             return true;
                         }
 


### PR DESCRIPTION
when gettime is not available, the value is probably a string and not a date so perform the request anyway to let the backend deal with it